### PR TITLE
Remove link to dead AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ If you want to uninstall the extension, you may invoke `make uninstall`, and the
 - [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE:Factory/gnome-shell-extension-pop-shell): `sudo zypper install gnome-shell-extension-pop-shell`
 - [Arch Linux](https://aur.archlinux.org/packages/?O=0&K=gnome-shell-extension-pop-shell) (Using Yay as AUR helper):
     - `yay -S gnome-shell-extension-pop-shell`
-    - For precompiled binary version: `yay -S gnome-shell-extension-pop-shell-bin`
     - For GitHub repository version: `yay -S gnome-shell-extension-pop-shell-git`
 
 ---


### PR DESCRIPTION
The pre-compiled Arch binary referenced in the README no longer exists in the AUR. 

[aur.archlinux.org/pkgbase/gnome-shell-extension-pop-shell-bin](https://aur.archlinux.org/pkgbase/gnome-shell-extension-pop-shell-bin)